### PR TITLE
Remove found check on GetPaused

### DIFF
--- a/x/tokenfactory/keeper/msg_server_burn.go
+++ b/x/tokenfactory/keeper/msg_server_burn.go
@@ -29,9 +29,6 @@ func (k msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.MsgBu
 	}
 
 	paused := k.GetPaused(ctx)
-	if !found {
-		return nil, sdkerrors.Wrapf(types.ErrBurn, "paused value is not found")
-	}
 
 	if paused.Paused {
 		return nil, sdkerrors.Wrapf(types.ErrBurn, "burning is paused")


### PR DESCRIPTION
This is a bug that was making it impossible to burn assets created by the tokenfactory. 